### PR TITLE
make report config work with latest iteration of hawkular reporter

### DIFF
--- a/reporter-config-base/src/test/resources/sample/hawkular-minimal.yaml
+++ b/reporter-config-base/src/test/resources/sample/hawkular-minimal.yaml
@@ -1,4 +1,5 @@
 hawkular:
   -
     tenant: 'my-tenant'
+    timeunit: 'SECONDS'
     period: 2

--- a/reporter-config3/pom.xml
+++ b/reporter-config3/pom.xml
@@ -112,7 +112,7 @@
         </dependency>
         <!-- hawkular -->
         <dependency>
-            <groupId>org.hawkular.client</groupId>
+            <groupId>org.hawkular.metrics</groupId>
             <artifactId>hawkular-dropwizard-reporter</artifactId>
             <classifier>shaded</classifier>
             <version>0.1.0-SNAPSHOT</version>

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/HawkularReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/HawkularReporterConfig.java
@@ -20,8 +20,8 @@ import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
-import org.hawkular.client.dropwizard.HawkularReporter;
-import org.hawkular.client.dropwizard.HawkularReporterNullableConfig;
+import org.hawkular.metrics.dropwizard.HawkularReporter;
+import org.hawkular.metrics.dropwizard.HawkularReporterNullableConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +53,16 @@ public class HawkularReporterConfig extends AbstractMetricReporterConfig impleme
     private Long tagsCacheDuration;
     @Valid
     private Boolean autoTagging;
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
 
     public String getUri() {
         return uri;
@@ -142,7 +152,7 @@ public class HawkularReporterConfig extends AbstractMetricReporterConfig impleme
 
     @Override
     public boolean enable(MetricRegistry registry) {
-        final String className = "org.hawkular.client.dropwizard.HawkularReporter";
+        final String className = "org.hawkular.metrics.dropwizard.HawkularReporter";
         if (!isClassAvailable(className)) {
             log.error("Tried to enable HawkularReporter, but class {} was not found", className);
             return false;

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/HawkularReporterConfigTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/HawkularReporterConfigTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.net.InetAddress;
+
 import org.hawkular.metrics.dropwizard.HawkularReporter;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
@@ -59,5 +61,27 @@ public class HawkularReporterConfigTest {
         assertEquals(0, hawkularReporter.getPerMetricTags().size());
         assertEquals(600000, hawkularReporter.getTagsCacheDuration());
         assertTrue(hawkularReporter.isEnableAutoTagging());
+    }
+
+    @Test
+    public void usePlainPrefix() {
+        String prefix = "test";
+        HawkularReporterConfig config = new HawkularReporterConfig();
+        config.setPrefix(prefix);
+        assertEquals(prefix, config.getPrefix());
+    }
+
+    @Test
+    public void useHostnamePrefix() throws Exception {
+        String prefix = "${host.name}";
+        HawkularReporterConfig config = new HawkularReporterConfig();
+        config.setPrefix(prefix);
+        assertEquals(sanitize(InetAddress.getLocalHost().getHostName()), config.getPrefix());
+    }
+
+    // For now this is copied from AbstractHostReporterConfig since the method is private, and it is just needed for
+    // a simple test.
+    private String sanitize(String string) {
+        return string.replaceAll("[^a-zA-Z0-9_-]", "_");
     }
 }

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/HawkularReporterConfigTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/HawkularReporterConfigTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.hawkular.client.dropwizard.HawkularReporter;
+import org.hawkular.metrics.dropwizard.HawkularReporter;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;


### PR DESCRIPTION
There were some compile errors due to package name changes. There were also a
couple failing tests. Most importantly, HawkularReporterConfig needed to
implement the getUsername and getPassword methods of
HawkularReporterNullableConfig. They are currently just empty methods right
now.